### PR TITLE
Fix: Unix time epoch bug in 'Saved' tab

### DIFF
--- a/app/src/main/java/com/simplified/wsstatussaver/WhatSaveViewModel.kt
+++ b/app/src/main/java/com/simplified/wsstatussaver/WhatSaveViewModel.kt
@@ -168,6 +168,11 @@ class WhatSaveViewModel(
         emit(SaveResult(isSaving = true))
         val result = repository.saveStatus(status, saveName)
         emit(SaveResult.single(result))
+        // After saving, we must manually refresh the "Saved" list
+        // so the user sees the new, correct data when they switch tabs.
+        if (result != null) {
+            loadSavedStatuses() //calls refresh function in the bg
+        }
     }
 
     fun saveStatuses(statuses: List<Status>): LiveData<SaveResult> = liveData(IO) {
@@ -175,6 +180,10 @@ class WhatSaveViewModel(
         val savedStatuses = repository.saveStatuses(statuses)
         val savedUris = savedStatuses.map { it.fileUri }
         emit(SaveResult(statuses = savedStatuses, uris = savedUris, saved = savedStatuses.size))
+        // Also refresh the "Saved" list here for consistency -- previously it worked by luck ig!
+        if (savedStatuses.isNotEmpty()) {
+            loadSavedStatuses()
+        }
     }
 
     fun deleteStatus(status: Status): LiveData<DeletionResult> = liveData(IO) {

--- a/app/src/main/java/com/simplified/wsstatussaver/fragments/statuses/SavedStatusesFragment.kt
+++ b/app/src/main/java/com/simplified/wsstatussaver/fragments/statuses/SavedStatusesFragment.kt
@@ -43,6 +43,13 @@ class SavedStatusesFragment : StatusesFragment() {
         }
     }
 
+    //Everytime the 'Saved' tab becomes visible -> Force reload
+    //So we beat the race condition that causing Unix time epoch
+    override fun onResume() {
+        super.onResume()
+        onRefresh()
+    }
+
     override fun createAdapter(): StatusAdapter =
         StatusAdapter(
             requireActivity(),

--- a/app/src/main/java/com/simplified/wsstatussaver/repository/StatusesRepository.kt
+++ b/app/src/main/java/com/simplified/wsstatussaver/repository/StatusesRepository.kt
@@ -294,7 +294,11 @@ class StatusesRepositoryImpl(
     }
 
     override suspend fun save(status: Status, saveName: String?): SavedStatus? {
-        val savable = status.toStatusEntity(saveName)
+        
+        //Timestamp issue fix!!
+        val currentTimeMillis = System.currentTimeMillis()
+        val savable = status.toStatusEntity(saveName, currentTimeMillis)
+
         val result = createSavedStatus(savable, true)?.also { status ->
             scanSavedStatus(listOf(status))
         }


### PR DESCRIPTION
When saving a single status, its "Saved date" in the "Saved" tab would incorrectly show as "1 Jan 1970" [Unix time epoch issue].
This was because the save timestamp was not being recorded in the function.
Even after fixing the timestamp, the "Saved" tab would not update its UI until a manual pull-to-refresh was performed, due to a state management race condition.
* [1] Timestamp issue for single status save fixed in `StatusesRepositoryImpl.kt`
* [2] Added a call to `loadSavedStatuses()` inside the `saveStatus` function. This ensures that after a single save completes, a refresh of the "Saved" list is immediately triggered.
* [3] Added an `onResume()` override to the `SavedStatusesFragment`. This function is called every time the Saved tab becomes visible. By calling `onRefresh()` (which calls `viewModel.loadSavedStatuses()`) inside `onResume()`, we make sure the "Saved" tab always loads the newest data from the database the moment it appears, defeating the race condition.